### PR TITLE
Update transformer patch

### DIFF
--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/elastic_width.py
@@ -27,6 +27,8 @@ import torch
 from torch import nn
 
 from nncf.common.graph import BaseLayerAttributes
+from nncf.common.graph import NNCFGraph
+from nncf.common.graph import NNCFNode
 from nncf.common.graph import NNCFNodeName
 from nncf.common.graph.layer_attributes import ConvolutionLayerAttributes
 from nncf.common.graph.layer_attributes import GenericWeightedLayerAttributes
@@ -39,7 +41,6 @@ from nncf.common.pruning.clusterization import Clusterization
 from nncf.common.pruning.mask_propagation import MaskPropagationAlgorithm
 from nncf.common.pruning.node_selector import PruningNodeSelector
 from nncf.common.pruning.structs import PrunedLayerInfoBase
-from nncf.common.pruning.utils import get_input_masks
 from nncf.common.pruning.utils import get_prunable_layers_in_out_channels
 from nncf.common.pruning.utils import is_prunable_depthwise_conv
 from nncf.common.pruning.shape_pruning_processor import ShapePruningProcessor
@@ -518,7 +519,8 @@ class ElasticWidthHandler(SingleElasticityHandler):
         prunable_types = [NNCFConv2d.op_func_name, NNCFLinear.op_func_name]
         self._shape_pruning_processor = ShapePruningProcessor(
             prunable_types=prunable_types,
-            pruning_operations_metatype=PT_PRUNING_OPERATOR_METATYPES)
+            pruning_operations_metatype=PT_PRUNING_OPERATOR_METATYPES,
+            get_input_masks_func=self.get_input_masks_with_add_dynamic_inputs)
         self._next_nodes = self._shape_pruning_processor.get_next_nodes(graph, pruned_module_groups_info)
         # Need a copy because it will be used for adding `output_mask`/`input_masks` to nodes that are relevant to
         # Elastic Width only and therefore it should be isolated to not intercept with other algorithms.
@@ -645,7 +647,7 @@ class ElasticWidthHandler(SingleElasticityHandler):
 
         for node_name, dynamic_input_width_op in self._node_name_vs_dynamic_input_width_op_map.items():
             node = self._propagation_graph.get_node_by_name(node_name)
-            input_masks = get_input_masks(node, self._propagation_graph)
+            input_masks = self.get_input_masks_with_add_dynamic_inputs(node, self._propagation_graph)
             was_set = False
             if input_masks:
                 input_mask = input_masks[0]
@@ -657,35 +659,41 @@ class ElasticWidthHandler(SingleElasticityHandler):
             if not was_set and node_name not in names_of_processed_nodes:
                 nncf_logger.debug(f'input width was not set in scope={node.node_name}')
 
-            if self._add_dynamic_inputs:
-                if node_name in self._add_dynamic_inputs and not was_set:
-                    nncf_logger.debug(f"setting input width by user's request for scope={node_name}")
-                    nodes_to_check = [node]
-                    while any(elem is None for elem in input_masks):
-                        previous_nodes = []
-                        for node in nodes_to_check:
-                            previous_nodes.append(self._propagation_graph.get_previous_nodes(node))
-                        nodes_to_check.clear()
-                        previous_nodes = [item for nodes in previous_nodes for item in nodes]
-                        if not previous_nodes:
-                            break
-                        for previous in previous_nodes:
-                            if 'output_mask' in previous.data:
-                                if previous.data['output_mask'] is not None:
-                                    input_masks.append(previous.data['output_mask'])
-                                    input_masks = [i for i in input_masks if i]
-                                else:
-                                    nodes_to_check.append(previous)
+    def get_input_masks_with_add_dynamic_inputs(self, node: NNCFNode, graph: NNCFGraph) -> List[Optional[NNCFTensor]]:
+        """
+        Returns input masks for all inputs of given NNCFNode.
+
+        :param node: Given NNCFNode.
+        :param graph: Graph to work with.
+        :return: Input masks.
+        """
+        retval = []
+        input_masks = [input_node.data['output_mask'] for input_node in graph.get_previous_nodes(node)]
+        if self._add_dynamic_inputs:
+            if node.node_name in self._add_dynamic_inputs and any(elem is None for elem in input_masks):
+                nncf_logger.debug(f"getting input mask by user's request for scope={node.node_name}")
+                nodes_to_check = [node]
+                while any(elem is None for elem in input_masks):
+                    previous_nodes = []
+                    for check_node in nodes_to_check:
+                        previous_nodes.append(graph.get_previous_nodes(check_node))
+                    nodes_to_check.clear()
+                    previous_nodes = [item for nodes in previous_nodes for item in nodes]
+                    if not previous_nodes:
+                        break
+                    for previous in previous_nodes:
+                        if 'output_mask' in previous.data:
+                            if previous.data['output_mask'] is not None:
+                                input_masks.append(previous.data['output_mask'])
+                                input_masks = [i for i in input_masks if i]
                             else:
                                 nodes_to_check.append(previous)
-                    if input_masks:
-                        input_mask = input_masks[0]
-                        input_width = self.mask_to_width(input_mask)
-                        if input_width:
-                            dynamic_input_width_op.set_active_width(input_width)
-                            was_set = True
-                    if was_set:
-                        nncf_logger.debug(f"Success setting up user's request for dynamic input at scope={node_name}")
+                        else:
+                            nodes_to_check.append(previous)
+
+        for input_mask in input_masks:
+            retval.append(input_mask[node.node_name] if isinstance(input_mask, dict) else input_mask)
+        return retval
 
     def get_active_in_out_width_values(self) -> Tuple[Dict[NNCFNodeName, int], Dict[NNCFNodeName, int]]:
         """

--- a/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
+++ b/nncf/experimental/torch/nas/bootstrapNAS/elasticity/multi_elasticity_handler.py
@@ -162,9 +162,7 @@ class MultiElasticityHandler(ElasticityHandler):
 
         :param config: elasticity configuration
         """
-        active_handlers = {
-            dim: self._handlers[dim] for dim in self._handlers if self._is_handler_enabled_map[dim]
-        }
+        active_handlers = self._get_active_handlers()
         for handler_id, handler in self._handlers.items():
             if handler_id in config:
                 sub_config = config[handler_id]
@@ -214,12 +212,10 @@ class MultiElasticityHandler(ElasticityHandler):
 
         :return: search space
         """
-        active_handlers = {
-            dim: self._handlers[dim] for dim in self._handlers if self._is_handler_enabled_map[dim]
-        }
+        active_handlers = self._get_active_handlers()
         space = {}
         for handler_id, handler in active_handlers.items():
-            space[handler_id.value] = handler.get_search_space()
+            space[handler_id] = handler.get_search_space()
         return space
 
     def enable_all(self) -> None:
@@ -283,6 +279,9 @@ class MultiElasticityHandler(ElasticityHandler):
             result = self._handlers[dim]
         return result
 
+    def _get_active_handlers(self) -> Dict[ElasticityDim, SingleElasticityHandler]:
+        return {dim: self._handlers[dim] for dim in self._handlers if self._is_handler_enabled_map[dim]}
+
     def _collect_handler_data_by_method_name(self, method_name: str) -> OrderedDictType[ElasticityDim, Any]:
         result = OrderedDict()
         for elasticity_dim, handler in self._handlers.items():
@@ -297,9 +296,7 @@ class MultiElasticityHandler(ElasticityHandler):
         return inspect.stack()[1].function
 
     def get_design_vars_info(self) -> float:
-        active_handlers = {
-            dim: self._handlers[dim] for dim in self._handlers if self._is_handler_enabled_map[dim]
-        }
+        active_handlers = self._get_active_handlers()
         num_vars = 0
         vars_upper = []
         for handler_id, handler in active_handlers.items():
@@ -313,9 +310,7 @@ class MultiElasticityHandler(ElasticityHandler):
         return num_vars, vars_upper
 
     def get_config_from_pymoo(self, x : List) -> SubnetConfig:
-        active_handlers = {
-            dim: self._handlers[dim] for dim in self._handlers if self._is_handler_enabled_map[dim]
-        }
+        active_handlers = self._get_active_handlers()
         index_pos = 0
         sample = SubnetConfig()
         for handler_id, _ in active_handlers.items():

--- a/tests/torch/nas/test_sanity_third_party.py
+++ b/tests/torch/nas/test_sanity_third_party.py
@@ -1,0 +1,178 @@
+"""
+ Copyright (c) 2022 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.shared.paths import PROJECT_ROOT
+from tests.torch.helpers import Command
+from tests.torch.test_sanity_third_party import TransformersVirtualEnvInstaller
+from tests.torch.test_sanity_third_party import create_command_line
+
+
+@pytest.fixture(scope='class')
+def temp_folder(tmp_path_factory):
+    root_folder = tmp_path_factory.mktemp('BootstrapNAS_third_party')
+    folders = {'models': root_folder / 'models',
+               'venv': root_folder / 'venv',
+               'repo': root_folder / 'repo'}
+    for folder in folders.values():
+        Path(folder).mkdir(exist_ok=True, parents=True)
+    return folders
+
+
+class BootstrapNASTransformersVirtualEnvInstaller(TransformersVirtualEnvInstaller):
+    def __init__(self, venv_path, repo_path):
+        super().__init__(venv_path, repo_path)
+        self.PATH_TO_PATCH = str(os.path.join(PROJECT_ROOT, "third_party_integration", "huggingface_transformers",
+                                        "BootstrapNAS_HF", "0001-Modifications-for-BootstrapNAS-usage.patch"))
+
+    def install_env(self, pip_cache_dir, torch_with_cuda11):
+        pip_runner = super().install_env(pip_cache_dir, torch_with_cuda11)
+        pip_runner.run_pip("install tensorboard")
+
+
+@pytest.mark.usefixtures('temp_folder')
+class TestBootstrapNASWithTransformers:
+    # pylint:disable=redefined-outer-name
+    @pytest.fixture(autouse=True)
+    def setup(self, temp_folder):
+        self.temp_folder = temp_folder
+        self.env = BootstrapNASTransformersVirtualEnvInstaller(temp_folder['venv'], temp_folder['repo'])
+
+    @pytest.mark.dependency(name='install_transformers')
+    def test_install_transformers_env(self, third_party, pip_cache_dir, torch_with_cuda11):
+        if not third_party:
+            pytest.skip('Skip tests of BootstrapNAS with patched transformers package '
+                        'since `--third-party-sanity` is False.')
+        self.env.install_env(pip_cache_dir, torch_with_cuda11)
+
+    @pytest.mark.dependency(depends=['install_transformers'], name='xnli_train')
+    def test_xnli_train(self, temp_folder):
+        com_line = "examples/pytorch/text-classification/run_xnli.py --model_name_or_path bert-base-chinese" \
+                   " --language zh --train_language zh --do_train --do_search --per_gpu_train_batch_size 24" \
+                   " --max_seq_length 128 --output_dir {} --evaluation_strategy epoch --max_eval_samples 10" \
+                   " --save_steps 200 --max_train_samples 10 --metric_for_best_model accuracy" \
+                   " --nncf_config nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_xnli.json" \
+            .format(os.path.join(temp_folder["models"], "xnli"))
+        runner = Command(create_command_line(com_line, self.env.VENV_ACTIVATE, self.env.PYTHON_EXECUTABLE,
+                                             self.env.CUDA_VISIBLE_STRING), self.env.TRANSFORMERS_REPO_PATH)
+        runner.run()
+        assert os.path.exists(os.path.join(temp_folder["models"], "xnli", "pytorch_model.bin"))
+        assert os.path.exists(os.path.join(temp_folder["models"], "xnli", "search_progression.csv"))
+
+    @pytest.mark.dependency(depends=['install_transformers', 'xnli_train'])
+    def test_xnli_eval(self, temp_folder):
+        com_line = "examples/pytorch/text-classification/run_xnli.py --model_name_or_path {output}" \
+                   " --language zh --do_eval --max_seq_length 128 --output_dir" \
+                   " {output} --nncf_config nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_xnli.json" \
+                   " --per_gpu_eval_batch_size 24 --max_eval_samples 10" \
+            .format(output=os.path.join(temp_folder["models"], "xnli"))
+        runner = Command(create_command_line(com_line, self.env.VENV_ACTIVATE, self.env.PYTHON_EXECUTABLE,
+                                             self.env.CUDA_VISIBLE_STRING), self.env.TRANSFORMERS_REPO_PATH)
+        runner.run()
+
+    @pytest.mark.dependency(depends=['install_transformers'], name='squad_train')
+    def test_squad_train(self, temp_folder):
+        com_line = "examples/pytorch/question-answering/run_qa.py --model_name_or_path " \
+                   "bert-large-uncased-whole-word-masking-finetuned-squad --dataset_name squad --do_train" \
+                   " --do_search --max_seq_length 384 --evaluation_strategy epoch --metric_for_best_model f1" \
+                   " --doc_stride 128 --output_dir {} --per_gpu_train_batch_size=1" \
+                   " --save_steps=200 --max_train_samples 10 --max_eval_samples 10" \
+                   " --nncf_config nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_squad.json" \
+            .format(os.path.join(temp_folder["models"], "squad"))
+        runner = Command(create_command_line(com_line, self.env.VENV_ACTIVATE, self.env.PYTHON_EXECUTABLE,
+                                             self.env.CUDA_VISIBLE_STRING), self.env.TRANSFORMERS_REPO_PATH)
+        runner.run()
+        assert os.path.exists(os.path.join(temp_folder["models"], "squad", "pytorch_model.bin"))
+        assert os.path.exists(os.path.join(temp_folder["models"], "squad", "search_progression.csv"))
+
+    @pytest.mark.dependency(depends=['install_transformers', 'squad_train'])
+    def test_squad_eval(self, temp_folder):
+        com_line = "examples/pytorch/question-answering/run_qa.py --model_name_or_path {output}" \
+                   " --do_eval --dataset_name squad  --max_eval_samples 10" \
+                   " --max_seq_length 384 --doc_stride 128 --per_gpu_eval_batch_size=4 --output_dir {output} " \
+                   " --nncf_config nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_squad.json" \
+            .format(output=os.path.join(temp_folder["models"], "squad"))
+        runner = Command(create_command_line(com_line, self.env.VENV_ACTIVATE, self.env.PYTHON_EXECUTABLE,
+                                             self.env.CUDA_VISIBLE_STRING), self.env.TRANSFORMERS_REPO_PATH)
+        runner.run()
+
+    @pytest.mark.dependency(depends=['install_transformers'], name='ner_train')
+    def test_ner_train(self, temp_folder):
+        com_line = "examples/pytorch/token-classification/run_ner.py --model_name_or_path bert-base-uncased" \
+                   " --do_train --do_search --per_gpu_train_batch_size 1" \
+                   " --dataset_name conll2003 --max_eval_samples 10" \
+                   " --max_train_samples 10 --evaluation_strategy epoch" \
+                   " --output_dir {} --metric_for_best_model accuracy" \
+                   " --nncf_config nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_conll.json" \
+            .format(os.path.join(temp_folder["models"], "ner_output"))
+        runner = Command(create_command_line(com_line, self.env.VENV_ACTIVATE, self.env.PYTHON_EXECUTABLE,
+                                             self.env.CUDA_VISIBLE_STRING), self.env.TRANSFORMERS_REPO_PATH)
+        runner.run()
+        assert os.path.exists(os.path.join(temp_folder["models"], "ner_output", "pytorch_model.bin"))
+        assert os.path.exists(os.path.join(temp_folder["models"], "ner_output", "search_progression.csv"))
+
+    @pytest.mark.dependency(depends=['install_transformers', 'ner_train'])
+    def test_ner_eval(self, temp_folder):
+        com_line = "examples/pytorch/token-classification/run_ner.py " \
+                   " --model_name_or_path {output} --do_eval " \
+                   " --output_dir {output} --dataset_name conll2003" \
+                   " --max_eval_samples 10" \
+                   " --nncf_config nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_conll.json" \
+            .format(output=os.path.join(temp_folder["models"], "ner_output"))
+        runner = Command(create_command_line(com_line, self.env.VENV_ACTIVATE, self.env.PYTHON_EXECUTABLE,
+                                             self.env.CUDA_VISIBLE_STRING), self.env.TRANSFORMERS_REPO_PATH)
+        runner.run()
+
+    @pytest.mark.dependency(depends=['install_transformers'], name='glue_train')
+    def test_glue_train(self, temp_folder):
+        com_line = "examples/pytorch/text-classification/run_glue.py --model_name_or_path" \
+                   " bert-base-cased-finetuned-mrpc --task_name mrpc --do_train --do_search --output_dir {}" \
+                   " --per_gpu_train_batch_size 4 --evaluation_strategy epoch --max_seq_length 128 " \
+                   " --max_train_samples 10 --max_eval_samples 10 --save_steps 200 --metric_for_best_model accuracy" \
+                   " --nncf_config nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_mrpc.json" \
+            .format(os.path.join(temp_folder["models"], "mrpc"))
+        runner = Command(create_command_line(com_line, self.env.VENV_ACTIVATE, self.env.PYTHON_EXECUTABLE,
+                                             self.env.CUDA_VISIBLE_STRING), self.env.TRANSFORMERS_REPO_PATH)
+        runner.run()
+        assert os.path.exists(os.path.join(temp_folder["models"], "mrpc", "pytorch_model.bin"))
+        assert os.path.exists(os.path.join(temp_folder["models"], "mrpc", "search_progression.csv"))
+
+    @pytest.mark.dependency(depends=['install_transformers', 'glue_train'])
+    def test_glue_eval(self, temp_folder):
+        com_line = "examples/pytorch/text-classification/run_glue.py --model_name_or_path {output}" \
+                   " --task_name mrpc --do_eval" \
+                   " --max_seq_length 128 --output_dir {output}" \
+                   " --max_eval_samples 10" \
+                   " --nncf_config nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_mrpc.json" \
+            .format(output=os.path.join(temp_folder["models"], "mrpc"))
+        runner = Command(create_command_line(com_line, self.env.VENV_ACTIVATE, self.env.PYTHON_EXECUTABLE,
+                                             self.env.CUDA_VISIBLE_STRING), self.env.TRANSFORMERS_REPO_PATH)
+        runner.run()
+
+    @pytest.mark.dependency(depends=['install_transformers'])
+    def test_convert_to_onnx(self, temp_folder):
+        com_line = "examples/pytorch/question-answering/run_qa.py --model_name_or_path {output} " \
+                   " --do_eval" \
+                   " --dataset_name squad " \
+                   " --max_eval_samples 10" \
+                   " --output_dir {output}" \
+                   " --to_onnx {output}/model.onnx" \
+                   " --nncf_config nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_squad.json" \
+            .format(output=os.path.join(temp_folder["models"], "squad"))
+        runner = Command(create_command_line(com_line, self.env.VENV_ACTIVATE, self.env.PYTHON_EXECUTABLE,
+                                             self.env.CUDA_VISIBLE_STRING), self.env.TRANSFORMERS_REPO_PATH)
+        runner.run()
+        assert os.path.exists(os.path.join(temp_folder["models"], "squad", "model.onnx"))

--- a/tests/torch/test_sanity_third_party.py
+++ b/tests/torch/test_sanity_third_party.py
@@ -89,7 +89,7 @@ class TransformersVirtualEnvInstaller:
                        cwd=self.TRANSFORMERS_REPO_PATH)
         subprocess.run("cp {} .".format(self.PATH_TO_PATCH), check=True, shell=True,
                        cwd=self.TRANSFORMERS_REPO_PATH)
-        subprocess.run("git apply 0001-Modifications-for-NNCF-usage.patch",
+        subprocess.run("git apply {}".format(os.path.basename(self.PATH_TO_PATCH)),
                        check=True, shell=True, cwd=self.TRANSFORMERS_REPO_PATH)
         pip_runner.run_pip("install .", cwd=self.TRANSFORMERS_REPO_PATH)
         pip_runner.run_pip("install -e \".[testing]\"", cwd=self.TRANSFORMERS_REPO_PATH)
@@ -100,6 +100,7 @@ class TransformersVirtualEnvInstaller:
         # WA for deleted CONLL2003 in datasets==1.11.0 (https://github.com/huggingface/datasets/issues/3582)
         pip_runner.run_pip("install -U datasets", cwd=self.TRANSFORMERS_REPO_PATH)
         pip_runner.run_pip("install -e .", cwd=PROJECT_ROOT)
+        return pip_runner
 
 
 # pylint:disable=redefined-outer-name

--- a/third_party_integration/huggingface_transformers/BootstrapNAS_HF/0001-Modifications-for-BootstrapNAS-usage.patch
+++ b/third_party_integration/huggingface_transformers/BootstrapNAS_HF/0001-Modifications-for-BootstrapNAS-usage.patch
@@ -1,4 +1,4 @@
-From 2fda2a7a6bb8dac775f8651d79176219d0bb2bc1 Mon Sep 17 00:00:00 2001
+From 4112c8fbe73464aff52c1e4e53ae3ccf87e11a30 Mon Sep 17 00:00:00 2001
 From: "J. Pablo Munoz" <pablo.munoz@intel.com>
 Date: Wed, 30 Nov 2022 17:00:14 -0800
 Subject: [PATCH] Enable BootstrapNAS
@@ -15,7 +15,7 @@ Subject: [PATCH] Enable BootstrapNAS
  .../nncf_bootstrapnas_bert_config_squad.json  |  69 +++++++++
  .../nncf_bootstrapnas_bert_config_xnli.json   |  65 ++++++++
  src/transformers/__init__.py                  |   4 +-
- src/transformers/modeling_utils.py            |  20 +++
+ src/transformers/modeling_utils.py            |  27 ++++
  src/transformers/models/bert/modeling_bert.py |   4 +-
  .../models/roberta/modeling_roberta.py        |   4 +-
  src/transformers/optimization.py              |  36 ++++-
@@ -23,12 +23,14 @@ Subject: [PATCH] Enable BootstrapNAS
  src/transformers/trainer.py                   | 146 +++++++++++++++---
  src/transformers/trainer_callback.py          |   6 +
  src/transformers/training_args.py             |  58 ++++++-
- src/transformers/utils/__init__.py            |   1 +
- 20 files changed, 879 insertions(+), 98 deletions(-)
+ src/transformers/utils/__init__.py            |   2 +
+ src/transformers/utils/bnas_utils.py          |  97 ++++++++++++
+ 21 files changed, 984 insertions(+), 98 deletions(-)
  create mode 100644 nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_conll.json
  create mode 100644 nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_mrpc.json
  create mode 100644 nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_squad.json
  create mode 100644 nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_xnli.json
+ create mode 100644 src/transformers/utils/bnas_utils.py
 
 diff --git a/examples/pytorch/language-modeling/run_clm.py b/examples/pytorch/language-modeling/run_clm.py
 index fe03cde7c..7f694f118 100755
@@ -1109,7 +1111,7 @@ index ba24b9886..c1d73c6d4 100755
      from .training_args_tf import TFTrainingArguments
  
 diff --git a/src/transformers/modeling_utils.py b/src/transformers/modeling_utils.py
-index 5f4fccd33..468335b48 100644
+index 5f4fccd33..3bee3521e 100644
 --- a/src/transformers/modeling_utils.py
 +++ b/src/transformers/modeling_utils.py
 @@ -27,6 +27,9 @@ from functools import partial
@@ -1122,7 +1124,15 @@ index 5f4fccd33..468335b48 100644
  from packaging import version
  from torch import Tensor, device, nn
  from torch.nn import CrossEntropyLoss
-@@ -1497,6 +1500,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
+@@ -59,6 +62,7 @@ from .utils import (
+     ContextManagers,
+     ModelOutput,
+     PushToHubMixin,
++    WeightsFlopsCalculatorForTransformer,
+     cached_file,
+     copy_func,
+     download_url,
+@@ -1497,6 +1501,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
          push_to_hub: bool = False,
          max_shard_size: Union[int, str] = "10GB",
          safe_serialization: bool = False,
@@ -1130,7 +1140,7 @@ index 5f4fccd33..468335b48 100644
          **kwargs,
      ):
          """
-@@ -1901,6 +1905,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
+@@ -1901,6 +1906,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
          load_in_8bit_skip_modules = kwargs.pop("load_in_8bit_skip_modules", None)
          subfolder = kwargs.pop("subfolder", "")
          commit_hash = kwargs.pop("_commit_hash", None)
@@ -1139,7 +1149,7 @@ index 5f4fccd33..468335b48 100644
  
          if trust_remote_code is True:
              logger.warning(
-@@ -2321,6 +2327,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
+@@ -2321,6 +2328,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
              if dtype_orig is not None:
                  torch.set_default_dtype(dtype_orig)
  
@@ -1148,12 +1158,15 @@ index 5f4fccd33..468335b48 100644
 +                algo_name = nncf_config.get('bootstrapNAS', {}).get('training', {}).get('algorithm', 'progressive_shrinking')
 +                compression_ctrl, model = create_compressed_model_from_algo_names(nncf_network, nncf_config,
 +                                                                                  algo_names=[algo_name])
++                compression_ctrl.multi_elasticity_handler._weights_calc = WeightsFlopsCalculatorForTransformer(
++                                                                            config.num_attention_heads,
++                                                                          )
 +                return compression_ctrl, model
 +
              model, missing_keys, unexpected_keys, mismatched_keys, error_msgs = cls._load_pretrained_model(
                  model,
                  state_dict,
-@@ -2344,6 +2357,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
+@@ -2344,6 +2361,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
          # Set model in evaluation mode to deactivate DropOut modules by default
          model.eval()
  
@@ -1162,6 +1175,9 @@ index 5f4fccd33..468335b48 100644
 +            algo_name = nncf_config.get('bootstrapNAS', {}).get('training', {}).get('algorithm', 'progressive_shrinking')
 +            compression_ctrl, model = create_compressed_model_from_algo_names(nncf_network, nncf_config,
 +                                                                              algo_names=[algo_name])
++            compression_ctrl.multi_elasticity_handler._weights_calc = WeightsFlopsCalculatorForTransformer(
++                                                                            config.num_attention_heads,
++                                                                      )
 +            return compression_ctrl, model
 +
          # Dispatch model with hooks on all devices if necessary
@@ -1775,10 +1791,18 @@ index 170315fe2..9e7df17fc 100644
 +    training_args.lr_scheduler_type = args.lr_scheduler_type
 +    training_args.max_steps = -1
 diff --git a/src/transformers/utils/__init__.py b/src/transformers/utils/__init__.py
-index 2269f2254..2e5b3fa1c 100644
+index 2269f2254..4aa93202a 100644
 --- a/src/transformers/utils/__init__.py
 +++ b/src/transformers/utils/__init__.py
-@@ -163,6 +163,7 @@ FLAX_WEIGHTS_INDEX_NAME = "flax_model.msgpack.index.json"
+@@ -22,6 +22,7 @@
+ from packaging import version
+ 
+ from .. import __version__
++from .bnas_utils import WeightsFlopsCalculatorForTransformer
+ from .constants import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD, IMAGENET_STANDARD_MEAN, IMAGENET_STANDARD_STD
+ from .doc import (
+     add_code_sample_docstrings,
+@@ -163,6 +164,7 @@ FLAX_WEIGHTS_INDEX_NAME = "flax_model.msgpack.index.json"
  SAFE_WEIGHTS_NAME = "model.safetensors"
  SAFE_WEIGHTS_INDEX_NAME = "model.safetensors.index.json"
  CONFIG_NAME = "config.json"
@@ -1786,6 +1810,109 @@ index 2269f2254..2e5b3fa1c 100644
  FEATURE_EXTRACTOR_NAME = "preprocessor_config.json"
  MODEL_CARD_NAME = "modelcard.json"
  
+diff --git a/src/transformers/utils/bnas_utils.py b/src/transformers/utils/bnas_utils.py
+new file mode 100644
+index 000000000..4631890b5
+--- /dev/null
++++ b/src/transformers/utils/bnas_utils.py
+@@ -0,0 +1,97 @@
++"""
++ Copyright (c) 2022 Intel Corporation
++ Licensed under the Apache License, Version 2.0 (the "License");
++ you may not use this file except in compliance with the License.
++ You may obtain a copy of the License at
++      http://www.apache.org/licenses/LICENSE-2.0
++ Unless required by applicable law or agreed to in writing, software
++ distributed under the License is distributed on an "AS IS" BASIS,
++ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ See the License for the specific language governing permissions and
++ limitations under the License.
++"""
++
++from typing import Dict
++from typing import List
++from typing import Tuple
++
++from nncf.common.graph import NNCFGraph
++from nncf.common.graph import NNCFNodeName
++from nncf.common.graph.operator_metatypes import OperatorMetatype
++from nncf.torch.graph.operator_metatypes import PTLinearMetatype
++from nncf.torch.graph.operator_metatypes import PTMatMulMetatype
++from nncf.common.pruning.weights_flops_calculator import WeightsFlopsCalculator
++
++
++class WeightsFlopsCalculatorForTransformer(WeightsFlopsCalculator):
++    """
++    Collection of weight and flops calculation functions.
++    Class instance keeps only parameters that are constant during
++    compression algorithms execution.
++    """
++
++    def __init__(self,
++                 n_heads: int,
++                 linear_op_metatypes: List[OperatorMetatype] = [PTLinearMetatype],
++                 matmul_op_metatypes: List[OperatorMetatype] = [PTMatMulMetatype]):
++        """
++        Constructor.
++
++        :param n_heads: number of attention heads.
++        :param linear_op_metatypes: List of metatypes defining linear/fully connected operations.
++        :param matmul_op_metatypes: List of metatypes defining matmul operations.
++        """
++        super().__init__([], linear_op_metatypes)
++        self._n_heads = n_heads
++        self._matmul_op_metatype = matmul_op_metatypes
++
++    def count_flops_and_weights_per_node(self,
++                                         graph: NNCFGraph,
++                                         output_shapes: Dict[NNCFNodeName, int],
++                                         input_channels: Dict[NNCFNodeName, int] = None,
++                                         output_channels: Dict[NNCFNodeName, int] = None,
++                                         kernel_sizes: Dict[NNCFNodeName, Tuple[int, int]] = None,
++                                         op_addresses_to_skip: List[NNCFNodeName] = None) -> \
++        Tuple[Dict[NNCFNodeName, int], Dict[NNCFNodeName, int]]:
++        """
++        Counts the number of weights and FLOPs per node in the model for convolution and fully connected layers.
++
++        :param graph: NNCFGraph.
++        :param output_shapes: Dictionary of output dimension shapes for convolutions and
++            fully connected layers. E.g {node_name: (height, width)}
++        :param input_channels: Dictionary of input channels number in convolutions.
++            If not specified, taken from the graph. {node_name: channels_num}
++        :param output_channels: Dictionary of output channels number in convolutions.
++            If not specified, taken from the graph. {node_name: channels_num}
++        :param kernel_sizes: Dictionary of kernel sizes in convolutions.
++            If not specified, taken from the graph. {node_name: kernel_size}.
++            It's only supposed to be used in NAS in case of Elastic Kernel enabled.
++        :param op_addresses_to_skip: List of operation addresses of layers that should be skipped from calculation.
++            It's only supposed to be used in NAS in case of Elastic Depth enabled.
++        :return Dictionary of FLOPs number {node_name: flops_num}
++                Dictionary of weights number {node_name: weights_num}
++        """
++        input_channels = input_channels or {}
++        output_channels = output_channels or {}
++        kernel_sizes = kernel_sizes or {}
++        op_addresses_to_skip = op_addresses_to_skip or []
++
++        flops, weights = super().count_flops_and_weights_per_node(graph, output_shapes, input_channels, output_channels,
++                                                                  kernel_sizes, op_addresses_to_skip)
++
++        for node in graph.get_nodes_by_metatypes(self._matmul_op_metatype):
++            name = node.node_name
++            if name in op_addresses_to_skip:
++                continue
++
++            # get previous qkv nodes
++            input_nodes = graph.get_previous_nodes(node)
++            while(len(input_nodes) > 0 and input_nodes[0].node_type != 'linear'):
++                input_nodes = graph.get_previous_nodes(input_nodes[0])
++            qkv_len = output_shapes[input_nodes[0].node_name][1]
++            qkv_head_dim = output_channels[input_nodes[0].node_name] // self._n_heads
++
++            flops[name] = 2 * self._n_heads * qkv_len * qkv_len * qkv_head_dim
++            weights[name] = 0
++
++        return flops, weights
 -- 
 2.17.1
 

--- a/third_party_integration/huggingface_transformers/BootstrapNAS_HF/0001-Modifications-for-BootstrapNAS-usage.patch
+++ b/third_party_integration/huggingface_transformers/BootstrapNAS_HF/0001-Modifications-for-BootstrapNAS-usage.patch
@@ -1,4 +1,4 @@
-From 4112c8fbe73464aff52c1e4e53ae3ccf87e11a30 Mon Sep 17 00:00:00 2001
+From 2fda2a7a6bb8dac775f8651d79176219d0bb2bc1 Mon Sep 17 00:00:00 2001
 From: "J. Pablo Munoz" <pablo.munoz@intel.com>
 Date: Wed, 30 Nov 2022 17:00:14 -0800
 Subject: [PATCH] Enable BootstrapNAS
@@ -15,7 +15,7 @@ Subject: [PATCH] Enable BootstrapNAS
  .../nncf_bootstrapnas_bert_config_squad.json  |  69 +++++++++
  .../nncf_bootstrapnas_bert_config_xnli.json   |  65 ++++++++
  src/transformers/__init__.py                  |   4 +-
- src/transformers/modeling_utils.py            |  27 ++++
+ src/transformers/modeling_utils.py            |  20 +++
  src/transformers/models/bert/modeling_bert.py |   4 +-
  .../models/roberta/modeling_roberta.py        |   4 +-
  src/transformers/optimization.py              |  36 ++++-
@@ -23,14 +23,12 @@ Subject: [PATCH] Enable BootstrapNAS
  src/transformers/trainer.py                   | 146 +++++++++++++++---
  src/transformers/trainer_callback.py          |   6 +
  src/transformers/training_args.py             |  58 ++++++-
- src/transformers/utils/__init__.py            |   2 +
- src/transformers/utils/bnas_utils.py          |  97 ++++++++++++
- 21 files changed, 984 insertions(+), 98 deletions(-)
+ src/transformers/utils/__init__.py            |   1 +
+ 20 files changed, 879 insertions(+), 98 deletions(-)
  create mode 100644 nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_conll.json
  create mode 100644 nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_mrpc.json
  create mode 100644 nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_squad.json
  create mode 100644 nncf_bootstrapnas_config/nncf_bootstrapnas_bert_config_xnli.json
- create mode 100644 src/transformers/utils/bnas_utils.py
 
 diff --git a/examples/pytorch/language-modeling/run_clm.py b/examples/pytorch/language-modeling/run_clm.py
 index fe03cde7c..7f694f118 100755
@@ -1111,7 +1109,7 @@ index ba24b9886..c1d73c6d4 100755
      from .training_args_tf import TFTrainingArguments
  
 diff --git a/src/transformers/modeling_utils.py b/src/transformers/modeling_utils.py
-index 5f4fccd33..3bee3521e 100644
+index 5f4fccd33..468335b48 100644
 --- a/src/transformers/modeling_utils.py
 +++ b/src/transformers/modeling_utils.py
 @@ -27,6 +27,9 @@ from functools import partial
@@ -1124,15 +1122,7 @@ index 5f4fccd33..3bee3521e 100644
  from packaging import version
  from torch import Tensor, device, nn
  from torch.nn import CrossEntropyLoss
-@@ -59,6 +62,7 @@ from .utils import (
-     ContextManagers,
-     ModelOutput,
-     PushToHubMixin,
-+    WeightsFlopsCalculatorForTransformer,
-     cached_file,
-     copy_func,
-     download_url,
-@@ -1497,6 +1501,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
+@@ -1497,6 +1500,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
          push_to_hub: bool = False,
          max_shard_size: Union[int, str] = "10GB",
          safe_serialization: bool = False,
@@ -1140,7 +1130,7 @@ index 5f4fccd33..3bee3521e 100644
          **kwargs,
      ):
          """
-@@ -1901,6 +1906,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
+@@ -1901,6 +1905,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
          load_in_8bit_skip_modules = kwargs.pop("load_in_8bit_skip_modules", None)
          subfolder = kwargs.pop("subfolder", "")
          commit_hash = kwargs.pop("_commit_hash", None)
@@ -1149,7 +1139,7 @@ index 5f4fccd33..3bee3521e 100644
  
          if trust_remote_code is True:
              logger.warning(
-@@ -2321,6 +2328,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
+@@ -2321,6 +2327,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
              if dtype_orig is not None:
                  torch.set_default_dtype(dtype_orig)
  
@@ -1158,15 +1148,12 @@ index 5f4fccd33..3bee3521e 100644
 +                algo_name = nncf_config.get('bootstrapNAS', {}).get('training', {}).get('algorithm', 'progressive_shrinking')
 +                compression_ctrl, model = create_compressed_model_from_algo_names(nncf_network, nncf_config,
 +                                                                                  algo_names=[algo_name])
-+                compression_ctrl.multi_elasticity_handler._weights_calc = WeightsFlopsCalculatorForTransformer(
-+                                                                            config.num_attention_heads,
-+                                                                          )
 +                return compression_ctrl, model
 +
              model, missing_keys, unexpected_keys, mismatched_keys, error_msgs = cls._load_pretrained_model(
                  model,
                  state_dict,
-@@ -2344,6 +2361,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
+@@ -2344,6 +2357,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
          # Set model in evaluation mode to deactivate DropOut modules by default
          model.eval()
  
@@ -1175,9 +1162,6 @@ index 5f4fccd33..3bee3521e 100644
 +            algo_name = nncf_config.get('bootstrapNAS', {}).get('training', {}).get('algorithm', 'progressive_shrinking')
 +            compression_ctrl, model = create_compressed_model_from_algo_names(nncf_network, nncf_config,
 +                                                                              algo_names=[algo_name])
-+            compression_ctrl.multi_elasticity_handler._weights_calc = WeightsFlopsCalculatorForTransformer(
-+                                                                            config.num_attention_heads,
-+                                                                      )
 +            return compression_ctrl, model
 +
          # Dispatch model with hooks on all devices if necessary
@@ -1791,18 +1775,10 @@ index 170315fe2..9e7df17fc 100644
 +    training_args.lr_scheduler_type = args.lr_scheduler_type
 +    training_args.max_steps = -1
 diff --git a/src/transformers/utils/__init__.py b/src/transformers/utils/__init__.py
-index 2269f2254..4aa93202a 100644
+index 2269f2254..2e5b3fa1c 100644
 --- a/src/transformers/utils/__init__.py
 +++ b/src/transformers/utils/__init__.py
-@@ -22,6 +22,7 @@
- from packaging import version
- 
- from .. import __version__
-+from .bnas_utils import WeightsFlopsCalculatorForTransformer
- from .constants import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD, IMAGENET_STANDARD_MEAN, IMAGENET_STANDARD_STD
- from .doc import (
-     add_code_sample_docstrings,
-@@ -163,6 +164,7 @@ FLAX_WEIGHTS_INDEX_NAME = "flax_model.msgpack.index.json"
+@@ -163,6 +163,7 @@ FLAX_WEIGHTS_INDEX_NAME = "flax_model.msgpack.index.json"
  SAFE_WEIGHTS_NAME = "model.safetensors"
  SAFE_WEIGHTS_INDEX_NAME = "model.safetensors.index.json"
  CONFIG_NAME = "config.json"
@@ -1810,109 +1786,6 @@ index 2269f2254..4aa93202a 100644
  FEATURE_EXTRACTOR_NAME = "preprocessor_config.json"
  MODEL_CARD_NAME = "modelcard.json"
  
-diff --git a/src/transformers/utils/bnas_utils.py b/src/transformers/utils/bnas_utils.py
-new file mode 100644
-index 000000000..4631890b5
---- /dev/null
-+++ b/src/transformers/utils/bnas_utils.py
-@@ -0,0 +1,97 @@
-+"""
-+ Copyright (c) 2022 Intel Corporation
-+ Licensed under the Apache License, Version 2.0 (the "License");
-+ you may not use this file except in compliance with the License.
-+ You may obtain a copy of the License at
-+      http://www.apache.org/licenses/LICENSE-2.0
-+ Unless required by applicable law or agreed to in writing, software
-+ distributed under the License is distributed on an "AS IS" BASIS,
-+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-+ See the License for the specific language governing permissions and
-+ limitations under the License.
-+"""
-+
-+from typing import Dict
-+from typing import List
-+from typing import Tuple
-+
-+from nncf.common.graph import NNCFGraph
-+from nncf.common.graph import NNCFNodeName
-+from nncf.common.graph.operator_metatypes import OperatorMetatype
-+from nncf.torch.graph.operator_metatypes import PTLinearMetatype
-+from nncf.torch.graph.operator_metatypes import PTMatMulMetatype
-+from nncf.common.pruning.weights_flops_calculator import WeightsFlopsCalculator
-+
-+
-+class WeightsFlopsCalculatorForTransformer(WeightsFlopsCalculator):
-+    """
-+    Collection of weight and flops calculation functions.
-+    Class instance keeps only parameters that are constant during
-+    compression algorithms execution.
-+    """
-+
-+    def __init__(self,
-+                 n_heads: int,
-+                 linear_op_metatypes: List[OperatorMetatype] = [PTLinearMetatype],
-+                 matmul_op_metatypes: List[OperatorMetatype] = [PTMatMulMetatype]):
-+        """
-+        Constructor.
-+
-+        :param n_heads: number of attention heads.
-+        :param linear_op_metatypes: List of metatypes defining linear/fully connected operations.
-+        :param matmul_op_metatypes: List of metatypes defining matmul operations.
-+        """
-+        super().__init__([], linear_op_metatypes)
-+        self._n_heads = n_heads
-+        self._matmul_op_metatype = matmul_op_metatypes
-+
-+    def count_flops_and_weights_per_node(self,
-+                                         graph: NNCFGraph,
-+                                         output_shapes: Dict[NNCFNodeName, int],
-+                                         input_channels: Dict[NNCFNodeName, int] = None,
-+                                         output_channels: Dict[NNCFNodeName, int] = None,
-+                                         kernel_sizes: Dict[NNCFNodeName, Tuple[int, int]] = None,
-+                                         op_addresses_to_skip: List[NNCFNodeName] = None) -> \
-+        Tuple[Dict[NNCFNodeName, int], Dict[NNCFNodeName, int]]:
-+        """
-+        Counts the number of weights and FLOPs per node in the model for convolution and fully connected layers.
-+
-+        :param graph: NNCFGraph.
-+        :param output_shapes: Dictionary of output dimension shapes for convolutions and
-+            fully connected layers. E.g {node_name: (height, width)}
-+        :param input_channels: Dictionary of input channels number in convolutions.
-+            If not specified, taken from the graph. {node_name: channels_num}
-+        :param output_channels: Dictionary of output channels number in convolutions.
-+            If not specified, taken from the graph. {node_name: channels_num}
-+        :param kernel_sizes: Dictionary of kernel sizes in convolutions.
-+            If not specified, taken from the graph. {node_name: kernel_size}.
-+            It's only supposed to be used in NAS in case of Elastic Kernel enabled.
-+        :param op_addresses_to_skip: List of operation addresses of layers that should be skipped from calculation.
-+            It's only supposed to be used in NAS in case of Elastic Depth enabled.
-+        :return Dictionary of FLOPs number {node_name: flops_num}
-+                Dictionary of weights number {node_name: weights_num}
-+        """
-+        input_channels = input_channels or {}
-+        output_channels = output_channels or {}
-+        kernel_sizes = kernel_sizes or {}
-+        op_addresses_to_skip = op_addresses_to_skip or []
-+
-+        flops, weights = super().count_flops_and_weights_per_node(graph, output_shapes, input_channels, output_channels,
-+                                                                  kernel_sizes, op_addresses_to_skip)
-+
-+        for node in graph.get_nodes_by_metatypes(self._matmul_op_metatype):
-+            name = node.node_name
-+            if name in op_addresses_to_skip:
-+                continue
-+
-+            # get previous qkv nodes
-+            input_nodes = graph.get_previous_nodes(node)
-+            while(len(input_nodes) > 0 and input_nodes[0].node_type != 'linear'):
-+                input_nodes = graph.get_previous_nodes(input_nodes[0])
-+            qkv_len = output_shapes[input_nodes[0].node_name][1]
-+            qkv_head_dim = output_channels[input_nodes[0].node_name] // self._n_heads
-+
-+            flops[name] = 2 * self._n_heads * qkv_len * qkv_len * qkv_head_dim
-+            weights[name] = 0
-+
-+        return flops, weights
 -- 
 2.17.1
 


### PR DESCRIPTION
### Changes 

#### commit 7e1cec7b56add01a24679dfc66beb4e0992ab179
1. Add sanity tests (tests/torch/nas/test_sanity_third_party.py) 

-  Following [sanity tests for NNCF patch](https://github.com/openvinotoolkit/nncf/blob/ba54e48c68d26fd114bdbb31c16126c6164e1f83/tests/torch/test_sanity_third_party.py#L106), I added tests for all tasks included in our patch.
 
- And also I made some minor modifications to reuse [TransformersVirtualEnvInstaller](https://github.com/openvinotoolkit/nncf/blob/ba54e48c68d26fd114bdbb31c16126c6164e1f83/tests/torch/test_sanity_third_party.py#L64). I am not sure if Nikolay thinks it is a good idea.

2. Modifications for multi_elasticity_handler

- Add private method _get_active_handlers()
- Change "handler_id.value" to "handler_id" in function get_search_space()

3. HuggingFace patch
- I keep a separate patch for BootstrapNAS instead of a one on top of the NNCF patch.
- For lr_scheduler, I added a class BNASLambdaLR that inherits from "torch.optim.lr_scheduler.LambdaLR".
- Add "register extra struct" for lr scheduler params.

#### commit 3a320091638573e9204fc2cf45681c107f63d6b8
4. Enable elastic QKV layer
- Just change the function "get_input_masks"

#### commit 1dab0e594548b852adafb712bbfc9fc277bdb08a
5. Add WeightsFlopsCalculatorForTransformer in HuggingFace patch
- Add flops count for matmul operators in self attention modules.

### Reason for changes
1. Keep a separate patch for BootstrapNAS instead of a one on top of the NNCF patch.

- One reason I keep a separate patch for BootstrapNAS is that if we use a patch based on the NNCF patch, we must always be in sync with the NNCF patch. Once it updates, we need to update our patch in the same commit.
- Another reason is that users need to apply two patches to use BootstrapNAS. I guess Nikolay will not think it is a good idea.

2. Add a class BNASLambdaLR 

In order to use our own controller and scheduler, we need to add some specific attributes in HuggingFace lr scheduler, such as ["epoch_step"](https://github.com/openvinotoolkit/nncf/blob/2c5ae0919cf714062ca39979235a0e2e1adb666e/nncf/experimental/torch/nas/bootstrapNAS/training/scheduler.py#L181) and ["stage_step"](https://github.com/openvinotoolkit/nncf/blob/2c5ae0919cf714062ca39979235a0e2e1adb666e/nncf/experimental/torch/nas/bootstrapNAS/training/scheduler.py#L185). BNASLambdaLR inherits from LambdaLR(lr scheduler used in HuggingFace) and also adds attributes required by our controller and scheduler. In this case, we are free to use almost any lr scheduler provided by HuggingFace.

3. Enable elastic QKV layer
When we prune QKV layers, we can reduce the FLOPs of both QKV layers and the following matmul operators at the same time. Pruning QKV layers is a more effective way to reduce FLOPs than just pruning intermediate linear layers and skipping modules.

### Tests

Add tests for BootstrapNAS HuggingFace patch
