### PR TITLE
Fix a test bug

### DIFF
--- a/tests/torch/pruning/filter_pruning/test_flops_pruning.py
+++ b/tests/torch/pruning/filter_pruning/test_flops_pruning.py
@@ -105,7 +105,7 @@ def test_init_params_for_flops_calculation(model, ref_params):
         (PruningTestModelSharedConvs, False, 0.4, 461438976, 275300352, [384, 768]),
         (GroupedConvolutionModel, False, 0.0, 11243520, 11243520, []),
         (PruningTestModelConcatWithLinear, False, 0.1, 305792, 230912, [16, 24, 24]),
-        (partial(MobilenetV3BlockSEReshape, mode='linear'), False, 0.1, 21360, 3532, [1, 1]),
+        (partial(MobilenetV3BlockSEReshape, mode='linear'), False, 0.1, 21360, 3042, [1, 1]),
         (PruningTestBatchedLinear, False, 0.0, 77824, 77824, []),
         (PruningTestModelBroadcastedLinear, False, 0.1, 137216, 103424, [16, 24]),
         (PruningTestModelDiffChInPruningCluster, False, 0.1, 1962368, 982336, [8]),


### PR DESCRIPTION
### Changes

I double checked the test and found that there is a bug in the original filter pruning test. Maybe this case can let Nikolay want to merge our PR. Thanks!

### Reason for changes

The old function cannot deal with the following test case `MobilenetV3BlockSEReshape`:
Here is part of the original graph of MobilenetV3BlockSEReshape:
![image](https://user-images.githubusercontent.com/107673535/229707417-43b35a43-3329-4b9b-83a9-9b8d0736a341.png)

For test case `MobilenetV3BlockSEReshape`, here is the result of `tmp_out_channels` and `tmp_in_channels` using the function in public NNCF: (`tmp_out_channels` and `tmp_in_channels` are generated [here](https://github.com/openvinotoolkit/nncf/blob/e4179127dc4b9b8591226d1268a9bc0f23f7f87d/nncf/torch/pruning/filter_pruning/algo.py#L638)):

```

tmp_out_channels = 
{
'MobilenetV3BlockSEReshape/NNCFConv2d[first_conv]/conv2d_0': 1,
'MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/NNCFConv2d[0]/conv2d_0': 1,
'MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/SELayerWithReshapeAndLinear[3]/Sequential[fc]/NNCFLinear[0]/linear_0': 1,
'MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/SELayerWithReshapeAndLinear[3]/Sequential[fc]/NNCFLinear[3]/linear_0': 1,
'MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/NNCFConv2d[4]/conv2d_0': 1,
'MobilenetV3BlockSEReshape/NNCFConv2d[last_conv]/conv2d_0': 1
}


tmp_in_channels = 
{
'MobilenetV3BlockSEReshape/NNCFConv2d[first_conv]/conv2d_0': 1,
'MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/NNCFConv2d[0]/conv2d_0': 1,
'MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/SELayerWithReshapeAndLinear[3]/Sequential[fc]/NNCFLinear[0]/linear_0': 1,
'MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/SELayerWithReshapeAndLinear[3]/Sequential[fc]/NNCFLinear[3]/linear_0': 1,
'MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/NNCFConv2d[4]/conv2d_0': 6,
'MobilenetV3BlockSEReshape/NNCFConv2d[last_conv]/conv2d_0': 1
}
```

We can see node `MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/NNCFConv2d[4]/conv2d_0: 6 ` in tmp_in_channels, which is incorrect.

This is because node `MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/NNCFConv2d[4]/conv2d_0` is in clusters(not in [next_nodes](https://github.com/openvinotoolkit/nncf/blob/e4179127dc4b9b8591226d1268a9bc0f23f7f87d/nncf/common/pruning/shape_pruning_processor.py#L133)) and it is not a [depthwise conv](https://github.com/openvinotoolkit/nncf/blob/e4179127dc4b9b8591226d1268a9bc0f23f7f87d/nncf/common/pruning/shape_pruning_processor.py#L129), so its input channel doesn't minus pruned elements.

Our PR can deal with this test case. If use our PR, 
 `MobilenetV3BlockSEReshape/InvertedResidual[inverted_residual]/Sequential[conv]/NNCFConv2d[4]/conv2d_0: 1` in tmp_in_channels

### Related tickets

N/A

### Tests

N/A
